### PR TITLE
Feat: 관심 매물 등록 & 조회 API 추가

### DIFF
--- a/src/main/java/dev/konkuk/home/domain/account/service/AccountService.java
+++ b/src/main/java/dev/konkuk/home/domain/account/service/AccountService.java
@@ -34,4 +34,9 @@ public class AccountService {
         return AccountDto.of(savedAccount);
     }
 
+    public Account findByEmail(String email) {
+        return accountRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("유저 조회 실패"));
+    }
+
 }

--- a/src/main/java/dev/konkuk/home/domain/favorite/api/FavoriteController.java
+++ b/src/main/java/dev/konkuk/home/domain/favorite/api/FavoriteController.java
@@ -1,0 +1,36 @@
+package dev.konkuk.home.domain.favorite.api;
+
+import dev.konkuk.home.domain.favorite.dto.FavoriteDto;
+import dev.konkuk.home.domain.favorite.service.FavoriteService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Api(tags = "관심 매물 API")
+@RequiredArgsConstructor
+@RequestMapping("/api/favorites")
+@RestController
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    @ApiOperation(value = "유저의 관심 매물 목록 조회 API")
+    @ApiImplicitParam(name = "email", value = "유저 이메일")
+    @GetMapping
+    public List<FavoriteDto.Response> getFavorites(@RequestParam String email) {
+        return favoriteService.getFavorites(email);
+    }
+
+    @ApiOperation(value = "관심 매물 등록 API", notes = "이미 등록된 매물일 경우 한 번 더 요청하면 취소 처리")
+    @ResponseStatus(value = HttpStatus.CREATED)
+    @PostMapping
+    public void createFavorite(@RequestBody FavoriteDto.Request favoriteRequestDto) {
+        favoriteService.createFavorite(favoriteRequestDto.getEmail(), favoriteRequestDto.getItemId());
+    }
+
+}

--- a/src/main/java/dev/konkuk/home/domain/favorite/dto/FavoriteDto.java
+++ b/src/main/java/dev/konkuk/home/domain/favorite/dto/FavoriteDto.java
@@ -1,0 +1,63 @@
+package dev.konkuk.home.domain.favorite.dto;
+
+import dev.konkuk.home.domain.favorite.entity.Favorite;
+import dev.konkuk.home.domain.property.constant.SalesType;
+import dev.konkuk.home.domain.property.constant.ServiceType;
+import dev.konkuk.home.domain.property.constant.Subway;
+import dev.konkuk.home.domain.property.entity.Property;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FavoriteDto {
+
+    @Getter @Setter
+    @Builder
+    public static class Request {
+        private String email;
+        private Long itemId;
+    }
+
+    @Getter @Setter
+    @Builder
+    public static class Response {
+        private Long itemId;
+        private SalesType salesType;
+        private ServiceType serviceType;
+        private String image_thumbnail;
+        private Long deposit;
+        private Long monthlyRentPrice;
+        private Double manageCost;
+        private Double area;
+        private String address;
+        private List<Subway> subways;
+
+        public static FavoriteDto.Response of(Favorite favorite) {
+            Property property = favorite.getProperty();
+
+            List<Subway> subways = new ArrayList<>();
+            subways.add(property.getSubway1());
+            subways.add(property.getSubway2());
+            if (property.getSubway3() != null) {
+                subways.add(property.getSubway3());
+            }
+
+            return FavoriteDto.Response.builder()
+                    .itemId(property.getItemId())
+                    .salesType(property.getSalesType())
+                    .serviceType(property.getServiceType())
+                    .image_thumbnail(property.getImageThumbnail())
+                    .area(property.getArea().getExclusiveArea())
+                    .address(property.getAddress().getFullAddress())
+                    .deposit(property.getDeposit())
+                    .manageCost(property.getManageCost())
+                    .monthlyRentPrice(property.getMonthlyRentPrice())
+                    .subways(subways)
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/dev/konkuk/home/domain/favorite/entity/Favorite.java
+++ b/src/main/java/dev/konkuk/home/domain/favorite/entity/Favorite.java
@@ -1,0 +1,50 @@
+package dev.konkuk.home.domain.favorite.entity;
+
+import dev.konkuk.home.domain.account.entity.Account;
+import dev.konkuk.home.domain.base.BaseTimeEntity;
+import dev.konkuk.home.domain.property.entity.Property;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Favorite extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long favoriteId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id")
+    private Property property;
+
+    @Builder
+    public Favorite(Account account, Property property) {
+        this.account = account;
+        this.property = property;
+    }
+
+    public static Favorite of(Account account, Property property) {
+        return Favorite.builder()
+                .account(account)
+                .property(property)
+                .build();
+    }
+
+    public static Favorite createFavorite(Favorite favorite) {
+        return Favorite.builder()
+                .account(favorite.getAccount())
+                .property(favorite.getProperty())
+                .build();
+    }
+
+}

--- a/src/main/java/dev/konkuk/home/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/dev/konkuk/home/domain/favorite/repository/FavoriteRepository.java
@@ -1,0 +1,17 @@
+package dev.konkuk.home.domain.favorite.repository;
+
+import dev.konkuk.home.domain.account.entity.Account;
+import dev.konkuk.home.domain.favorite.entity.Favorite;
+import dev.konkuk.home.domain.property.entity.Property;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    Optional<Favorite> findByAccountAndProperty(Account account, Property property);
+
+    List<Favorite> findAllByAccount(Account account);
+
+}

--- a/src/main/java/dev/konkuk/home/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/dev/konkuk/home/domain/favorite/service/FavoriteService.java
@@ -1,0 +1,48 @@
+package dev.konkuk.home.domain.favorite.service;
+
+import dev.konkuk.home.domain.account.entity.Account;
+import dev.konkuk.home.domain.account.service.AccountService;
+import dev.konkuk.home.domain.favorite.dto.FavoriteDto;
+import dev.konkuk.home.domain.favorite.entity.Favorite;
+import dev.konkuk.home.domain.favorite.repository.FavoriteRepository;
+import dev.konkuk.home.domain.property.entity.Property;
+import dev.konkuk.home.domain.property.service.PropertyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final AccountService accountService;
+    private final PropertyService propertyService;
+
+    public List<FavoriteDto.Response> getFavorites(String email) {
+        Account account = accountService.findByEmail(email);
+        return favoriteRepository.findAllByAccount(account).stream()
+                .map(FavoriteDto.Response::of)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void createFavorite(String email, Long itemId) {
+        Account account = accountService.findByEmail(email);
+        Property property = propertyService.getById(itemId);
+
+        /* 이미 등록해놨을 경우 취소(삭제), 아닐 경우 관심 매물 등록 진행 */
+        favoriteRepository.findByAccountAndProperty(account, property)
+                .ifPresentOrElse(favoriteRepository::delete,
+                        () -> {
+                            Favorite favorite = Favorite.of(account, property);
+                            favorite = Favorite.createFavorite(favorite);
+                            favoriteRepository.save(favorite);
+                        });
+    }
+
+}

--- a/src/main/java/dev/konkuk/home/domain/property/service/PropertyService.java
+++ b/src/main/java/dev/konkuk/home/domain/property/service/PropertyService.java
@@ -58,4 +58,8 @@ public class PropertyService {
 //        return properties.parallelStream().map(property ->
 //                PropertySimpleDto.of(property)).collect(Collectors.toList());
 //    }
+
+    public Property getById(Long itemId) {
+        return propertyRepository.getById(itemId);
+    }
 }


### PR DESCRIPTION
[관심 매물 등록]
- 유저 이메일, 매물 아이디를 받아 등록
- 이미 등록된 매물을 또 등록 요청할 경우 취소로 간주하여 관심 매물 목록에서 해당 매물 삭제 처리

[관심 매물 조회]
- 유저 이메일을 받아 유저의 관심 매물 목록 반환